### PR TITLE
add meta parameter to actions

### DIFF
--- a/modules/middleware.js
+++ b/modules/middleware.js
@@ -14,7 +14,7 @@ export default function apiMiddleware ({ dispatch }) {
       return next(action);
     }
 
-    const { types, promise } = definition;
+    const { types, meta, promise } = definition;
     const [REQUEST, SUCCESS, FAILURE] = types;
 
     if (!isPromise(promise)) {
@@ -26,13 +26,15 @@ export default function apiMiddleware ({ dispatch }) {
     }
 
     dispatch({
-      type: REQUEST
+      type: REQUEST,
+      meta
     });
 
     return promise.then(data => {
       process.nextTick(() => dispatch({
         type: SUCCESS,
-        payload: data
+        payload: data,
+        meta
       }));
 
       return data;
@@ -40,7 +42,8 @@ export default function apiMiddleware ({ dispatch }) {
       process.nextTick(() => dispatch({
         type: FAILURE,
         payload: err,
-        error: true
+        error: true,
+        meta
       }));
     });
   };


### PR DESCRIPTION
This adds the ability to specify the `meta` parameter, in line with the available parameters in fsa. In the wild, usage would look something like this:

``` js
export function fetchInventoryTransactions (organizationId, options = DEFAULT_FETCH_INVENTORY_TRANSACTIONS_OPTIONS) {
  return (dispatch, getState) => {
    var params = {};
    const { nextPage } = options;
    if (options.nextPage) {
      const { inventoryTransactions } = getState();
      const lastTransaction = _.last(inventoryTransactions.entities);
      params.startingAfter = _.get(lastTransaction, 'id');
    }
    dispatch({
      [CALL_API]: {
        types: [
          FETCH_INVENTORY_TRANSACTIONS_REQUEST,
          FETCH_INVENTORY_TRANSACTIONS_SUCCESS,
          FETCH_INVENTORY_TRANSACTIONS_FAILURE
        ],
        promise: Meadow.getInventoryTransactions(organizationId, params),
        meta: {
          nextPage: options.nextPage
        }
      }
    });
  };
};
```
